### PR TITLE
OnComplete(nRecordLimit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ func (p *Plugin) OnRecordPacket(connection sdk.InputConnection) {
 	}
 }
 
-func (p *Plugin) OnComplete() {
+func (p *Plugin) OnComplete(nRecordLimit int64) {
 	p.provider.Io().Info(`Done`)
 }
 ```
@@ -132,7 +132,7 @@ type Plugin interface {
 	Init(Provider)
 	OnInputConnectionOpened(InputConnection)
 	OnRecordPacket(InputConnection)
-	OnComplete()
+	OnComplete(nRecordLimit int64)
 }
 ```
 
@@ -142,7 +142,7 @@ The `OnInputConnectionOpened` function is called when an upstream tool is connec
 
 The `OnRecordPacket` function is called when your custom tool recieves records from an upstream tool.  Your tool is given an [InputConnection](#Using-InputConnection), which allows you to check the incoming connection name, iterate through the incoming records, and retrieve the progress of the incoming datastream.  As with `OnInputConnectionOpened`, this function is not called if your custom tool is an input tool.
 
-The `OnComplete` function is called at the end of your custom tool's lifecycle.  For tools which receive data from upstream tools, this happens after all incoming connections have been closed by the upstream tools.  For input tools, this happens when Alteryx is ready for your tool to start processing and sending data.
+The `OnComplete` function is called at the end of your custom tool's lifecycle. For tools which receive data from upstream tools, this happens after all incoming connections have been closed by the upstream tools.  For input tools, this happens when Alteryx is ready for your tool to start processing and sending data. TODO: explain the `nRecordLimit` argument.
 
 Below is an example of a struct that implements the Plugin interface:
 
@@ -175,7 +175,7 @@ func (p *Plugin) OnRecordPacket(connection sdk.InputConnection) {
 	}
 }
 
-func (p *Plugin) OnComplete() {}
+func (p *Plugin) OnComplete(nRecordLimit int64) {}
 ```
 
 [Back to table of contents](#Table-of-contents)
@@ -468,7 +468,7 @@ func (p *Plugin) OnRecordPacket(connection sdk.InputConnection) {
 	}
 }
 
-func (p *Plugin) OnComplete() {}
+func (p *Plugin) OnComplete(nRecordLimit int64) {}
 ```
 
 #### EditingRecordInfo
@@ -597,7 +597,7 @@ func (p *Plugin) OnRecordPacket(connection sdk.InputConnection) {
 	}
 }
 
-func (p *Plugin) OnComplete() {}
+func (p *Plugin) OnComplete(nRecordLimit int64) {}
 ```
 
 [Back to table of contents](#Table-of-contents)

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The `OnInputConnectionOpened` function is called when an upstream tool is connec
 
 The `OnRecordPacket` function is called when your custom tool recieves records from an upstream tool.  Your tool is given an [InputConnection](#Using-InputConnection), which allows you to check the incoming connection name, iterate through the incoming records, and retrieve the progress of the incoming datastream.  As with `OnInputConnectionOpened`, this function is not called if your custom tool is an input tool.
 
-The `OnComplete` function is called at the end of your custom tool's lifecycle. For tools which receive data from upstream tools, this happens after all incoming connections have been closed by the upstream tools.  For input tools, this happens when Alteryx is ready for your tool to start processing and sending data. TODO: explain the `nRecordLimit` argument.
+The `OnComplete` function is called at the end of your custom tool's lifecycle. For tools which receive data from upstream tools, this happens after all incoming connections have been closed by the upstream tools.  For input tools, this happens when Alteryx is ready for your tool to start processing and sending data.  A single argument `nRecordLimit` is passed to `OnComplete`. Your tool's implementation should use `nRecordLimit` to determine the number of records to output. `nRecordLimit` will be <0 to indicate that there is no limit, 0 to indicate that the tool is being configured and no records should be sent, or >0 to indicate that only the requested number of records should be sent.
 
 Below is an example of a struct that implements the Plugin interface:
 

--- a/examples/plugin.go
+++ b/examples/plugin.go
@@ -56,6 +56,6 @@ func (p *Plugin) OnRecordPacket(connection sdk.InputConnection) {
 	}
 }
 
-func (p *Plugin) OnComplete() {
+func (p *Plugin) OnComplete(nRecordLimit int64) {
 	p.provider.Io().Info(`Done`)
 }

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -4,5 +4,5 @@ type Plugin interface {
 	Init(Provider)
 	OnInputConnectionOpened(InputConnection)
 	OnRecordPacket(InputConnection)
-	OnComplete()
+	OnComplete(nRecordLimit int64)
 }

--- a/sdk/sdk.c
+++ b/sdk/sdk.c
@@ -528,7 +528,7 @@ void II_Close(void * handle) {
     if (plugin->totalInputConnections != plugin->closedInputConnections) {
         return;
     }
-    complete(plugin);
+    //complete(plugin, nRecordLimit);
 }
 
 void II_CloseNoCache(void * handle) {
@@ -541,7 +541,7 @@ void II_CloseNoCache(void * handle) {
     if (plugin->totalInputConnections != plugin->closedInputConnections) {
         return;
     }
-    complete(plugin);
+    //complete(plugin, nRecordLimit);
 }
 
 void II_Free(void * handle) {

--- a/sdk/sdk.c
+++ b/sdk/sdk.c
@@ -269,8 +269,8 @@ void freeAllOutputAnchors(struct OutputAnchor *anchor) {
     }
 }
 
-void complete(struct PluginSharedMemory *plugin) {
-    goOnComplete(plugin);
+void complete(struct PluginSharedMemory *plugin, int64_t nRecordLimit) {
+    goOnComplete(plugin, nRecordLimit);
     freeAllInputAnchors(plugin->inputAnchors);
     closeAllOutputAnchors(plugin->outputAnchors);
     freeAllOutputAnchors(plugin->outputAnchors);
@@ -281,7 +281,7 @@ void complete(struct PluginSharedMemory *plugin) {
 
 long PI_PushAllRecords(void * handle, int64_t nRecordLimit){
     struct PluginSharedMemory *plugin = (struct PluginSharedMemory*)handle;
-    complete(plugin);
+    complete(plugin, nRecordLimit);
     return 1;
 }
 

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -413,10 +413,10 @@ func goOnRecordPacketNoCache(handle unsafe.Pointer) {
 }
 
 //export goOnComplete
-func goOnComplete(handle unsafe.Pointer) {
+func goOnComplete(handle unsafe.Pointer, nRecordLimit int64) {
 	data := (*goPluginSharedMemory)(handle)
 	implementation := tools[data]
-	implementation.OnComplete()
+	implementation.OnComplete(nRecordLimit)
 	for anchor := data.outputAnchors; anchor != nil; anchor = anchor.nextAnchor {
 		if anchor.recordCachePosition > 0 {
 			callWriteRecords(unsafe.Pointer(anchor))

--- a/sdk/sdk.h
+++ b/sdk/sdk.h
@@ -100,7 +100,7 @@ void II_Free(void * handle);
 void goOnInputConnectionOpened(void * handle);
 void goOnRecordPacket(void * handle);
 void goOnRecordPacketNoCache(void * handle);
-void goOnComplete(void * handle);
+void goOnComplete(void * handle, int64_t nRecordLimit);
 void callWriteRecord(struct OutputAnchor *anchor);
 void callWriteRecords(struct OutputAnchor *anchor);
 void* allocateCache(int size);

--- a/sdk/sdk_internal_test.go
+++ b/sdk/sdk_internal_test.go
@@ -10,7 +10,7 @@ func (t *InternalTest) OnInputConnectionOpened(_ InputConnection) {}
 
 func (t *InternalTest) OnRecordPacket(_ InputConnection) {}
 
-func (t *InternalTest) OnComplete() {}
+func (t *InternalTest) OnComplete(nRecordLimit int64) {}
 
 func TestPluginsAreRemovedAfterOnComplete(t *testing.T) {
 	if len(tools) != 0 {

--- a/sdk/sdk_nocache_test.go
+++ b/sdk/sdk_nocache_test.go
@@ -29,7 +29,7 @@ func (n *NoCache) OnRecordPacket(connection sdk.InputConnection) {
 	}
 }
 
-func (n *NoCache) OnComplete() {
+func (n *NoCache) OnComplete(nRecordLimit int64) {
 }
 
 func TestNoCache(t *testing.T) {

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -45,7 +45,7 @@ func (t *TestImplementation) OnRecordPacket(_ sdk.InputConnection) {
 	t.DidOnRecordPacket = true
 }
 
-func (t *TestImplementation) OnComplete() {
+func (t *TestImplementation) OnComplete(nRecordLimit int64) {
 	t.DidOnComplete = true
 	t.Output.UpdateProgress(1)
 }
@@ -69,7 +69,7 @@ func (i *TestInputTool) OnRecordPacket(_ sdk.InputConnection) {
 	panic("This should never be called")
 }
 
-func (i *TestInputTool) OnComplete() {
+func (i *TestInputTool) OnComplete(nRecordLimit int64) {
 	source := `source`
 	output, _ := sdk.NewOutgoingRecordInfo([]sdk.NewOutgoingField{
 		sdk.NewBlobField(`Field1`, source, 100),
@@ -130,7 +130,7 @@ func (i *InputRecordLargerThanCache) OnRecordPacket(_ sdk.InputConnection) {
 	panic("this should never be called")
 }
 
-func (i *InputRecordLargerThanCache) OnComplete() {
+func (i *InputRecordLargerThanCache) OnComplete(nRecordLimit int64) {
 	info, _ := sdk.NewOutgoingRecordInfo([]sdk.NewOutgoingField{
 		sdk.NewV_WStringField(`Field1`, `source`, 1000000000),
 	})
@@ -159,7 +159,7 @@ func (i *InputWithNulls) OnRecordPacket(_ sdk.InputConnection) {
 	panic("this should never be called")
 }
 
-func (i *InputWithNulls) OnComplete() {
+func (i *InputWithNulls) OnComplete(nRecordLimit int64) {
 	info, _ := sdk.NewOutgoingRecordInfo([]sdk.NewOutgoingField{
 		sdk.NewBoolField(`Field1`, `source`),
 		sdk.NewInt32Field(`Field2`, `source`),
@@ -214,7 +214,7 @@ func (p *PassThroughTool) OnRecordPacket(connection sdk.InputConnection) {
 	}
 }
 
-func (p *PassThroughTool) OnComplete() {}
+func (p *PassThroughTool) OnComplete(nRecordLimit int64) {}
 
 func TestRegister(t *testing.T) {
 	config := `<Configuration></Configuration>`
@@ -536,7 +536,7 @@ func (p *WriteBeforeOpeningOutput) OnRecordPacket(connection sdk.InputConnection
 	}
 }
 
-func (p *WriteBeforeOpeningOutput) OnComplete() {
+func (p *WriteBeforeOpeningOutput) OnComplete(nRecordLimit int64) {
 }
 
 func TestWritingOutputBeforeOpenShouldPanic(t *testing.T) {
@@ -582,7 +582,7 @@ func (i *OpenBeforeAddingConnectionPlugin) OnRecordPacket(connection sdk.InputCo
 	}
 }
 
-func (i *OpenBeforeAddingConnectionPlugin) OnComplete() {}
+func (i *OpenBeforeAddingConnectionPlugin) OnComplete(nRecordLimit int64) {}
 
 func TestInitOutputBeforeAddingOutgoingConnection(t *testing.T) {
 	plugin := &OpenBeforeAddingConnectionPlugin{}
@@ -645,7 +645,7 @@ func (t *statusTester) OnRecordPacket(connection sdk.InputConnection) {
 	}
 }
 
-func (t *statusTester) OnComplete() {
+func (t *statusTester) OnComplete(nRecordLimit int64) {
 	t.checkExpectedConn1Status(sdk.Closed)
 	if t.connection2 != nil {
 		t.checkExpectedConn2Status(sdk.Closed)
@@ -707,7 +707,7 @@ func (t *outputAnchorCloseTester) OnRecordPacket(_ sdk.InputConnection) {
 	panic("implement me")
 }
 
-func (t *outputAnchorCloseTester) OnComplete() {
+func (t *outputAnchorCloseTester) OnComplete(nRecordLimit int64) {
 	if t.err != nil {
 		return
 	}
@@ -743,7 +743,7 @@ func (t *testCreateTempFile) OnInputConnectionOpened(_ sdk.InputConnection) {}
 
 func (t *testCreateTempFile) OnRecordPacket(_ sdk.InputConnection) {}
 
-func (t *testCreateTempFile) OnComplete() {}
+func (t *testCreateTempFile) OnComplete(nRecordLimit int64) {}
 
 func TestCreateTempFile(t *testing.T) {
 	plugin := &testCreateTempFile{}
@@ -770,7 +770,7 @@ func (b *byteTester) OnInputConnectionOpened(_ sdk.InputConnection) {
 func (b *byteTester) OnRecordPacket(_ sdk.InputConnection) {
 }
 
-func (b *byteTester) OnComplete() {
+func (b *byteTester) OnComplete(nRecordLimit int64) {
 	info, _ := sdk.NewOutgoingRecordInfo([]sdk.NewOutgoingField{
 		sdk.NewByteField(`bytes`, `Byte Tester`),
 	})

--- a/sdk/test_runner.go
+++ b/sdk/test_runner.go
@@ -76,7 +76,7 @@ func (f *FilePusher) OnRecordPacket(_ InputConnection) {
 	panic("this should never be called")
 }
 
-func (f *FilePusher) OnComplete() {
+func (f *FilePusher) OnComplete(nRecordLimit int64) {
 	file, err := os.Open(f.file)
 	if err != nil {
 		panic(fmt.Sprintf(`error opening data file: %v`, err.Error()))
@@ -278,7 +278,7 @@ func (r *RecordCollector) OnRecordPacket(connection InputConnection) {
 	r.Progress = connection.Progress()
 }
 
-func (r *RecordCollector) OnComplete() {}
+func (r *RecordCollector) OnComplete(nRecordLimit int64) {}
 
 func (r *RecordCollector) appendDataToField(fieldName string, value interface{}, isNull bool) {
 	if isNull {


### PR DESCRIPTION
This updates the OnComplete handler interface to utilize the `nRecordLimit` argument that is provided by `PI_PushAllRecords`. The Alteryx C++ SDK doc explains this parameter:

> The nRecordLimit parameter will be <0 to indicate that there is no limit, 0 to indicate that the tool is being configured and no records should be sent, or >0 to indicate that only the requested number of records should be sent.

For input tools, I've confirmed that it is necessary to test for `nRecordLimit == 0` in `OnComplete` and returning before records are generated in order to prevent full data generation at "design time" when an Alteryx user completes configuring the tool property settings.

Note, that I removed the calls to `complete` in `II_Close` and `II_CloseNoCache` since the record limit isn't available in those contexts. This seems to be fine for an input tool but needs review to ensure it isn't breaking other types of tools (I assume it was there originally for a reason).